### PR TITLE
Add: New Routes for dashboard after successfully creating store name

### DIFF
--- a/app/(dashboard)/[storeId]/(routes)/page.tsx
+++ b/app/(dashboard)/[storeId]/(routes)/page.tsx
@@ -1,0 +1,5 @@
+const DashboardPage = () => {
+  return <div>This is DashboardPage</div>;
+};
+
+export default DashboardPage;

--- a/app/(dashboard)/[storeId]/layout.tsx
+++ b/app/(dashboard)/[storeId]/layout.tsx
@@ -1,0 +1,36 @@
+import prismadb from "@/lib/prismadb";
+import { auth } from "@clerk/nextjs";
+import { redirect } from "next/navigation";
+import React from "react";
+
+export default async function DashboardLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: { storeId: string };
+}) {
+  const { userId } = auth();
+
+  if (!userId) {
+    redirect("/sign-in");
+  }
+
+  const store = await prismadb.store.findFirst({
+    where: {
+      id: params.storeId,
+      userId,
+    },
+  });
+
+  if (!store) {
+    redirect("/");
+  }
+
+  return (
+    <>
+      <div>This will be a Navbar</div>
+      {children}
+    </>
+  );
+}

--- a/app/(root)/(routes)/page.tsx
+++ b/app/(root)/(routes)/page.tsx
@@ -13,7 +13,7 @@ const SetupPage = () => {
     }
   }, [isOpen, onOpen]);
 
-  return <div className="p-4">Root Page</div>;
+  return null;
 };
 
 export default SetupPage;

--- a/app/(root)/layout.tsx
+++ b/app/(root)/layout.tsx
@@ -1,0 +1,27 @@
+import prismadb from "@/lib/prismadb";
+import { auth } from "@clerk/nextjs";
+import { redirect } from "next/navigation";
+
+export default async function SetupLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { userId } = auth();
+
+  if (!userId) {
+    redirect("/sign-in");
+  }
+
+  const store = await prismadb.store.findFirst({
+    where: {
+      userId,
+    },
+  });
+
+  if (store) {
+    redirect(`/${store.id}`);
+  }
+
+  return <>{children}</>;
+}

--- a/components/modals/store-modal.tsx
+++ b/components/modals/store-modal.tsx
@@ -41,7 +41,7 @@ export const StoreModal = () => {
 
       const response = await axios.post("/api/stores", values);
 
-      toast.success("Store created.");
+      window.location.assign(`/${response.data.id}`);
     } catch (error) {
       toast.error("Something went wrong");
     } finally {


### PR DESCRIPTION
will check if the user is auth, if not go back to sign-in page, if auth then find in the database then appear the modal-store
create a name for the store where the auth user who's logged in, and save to database and redirect to the dashboard
with a url link of auth userId